### PR TITLE
Rename AvroSchemaCompatibility.apply params to `schema1` and `schema2`

### DIFF
--- a/core/src/main/scala/formulation/AvroSchemaCompatibility.scala
+++ b/core/src/main/scala/formulation/AvroSchemaCompatibility.scala
@@ -29,14 +29,14 @@ object AvroSchemaCompatibility {
 
   val all = Set(None, Forward, Backward, Full)
 
-  def apply(writer: Schema, reader: Schema): AvroSchemaCompatibility =
-    (isCompatible(writer)(reader), isCompatible(reader)(writer)) match {
+  def apply(schema1: Schema, schema2: Schema): AvroSchemaCompatibility =
+    (isCompatible(schema1)(schema2), isCompatible(schema2)(schema1)) match {
       case (false, true) => Backward
       case (true, false) => Forward
       case (true, true) => Full
       case (false, false) => None
     }
 
-  private def isCompatible(target: Schema)(comparison: Schema): Boolean =
-    SchemaCompatibility.checkReaderWriterCompatibility(target, comparison).getType == COMPATIBLE
+  private def isCompatible(reader: Schema)(writer: Schema): Boolean =
+    SchemaCompatibility.checkReaderWriterCompatibility(reader, writer).getType == COMPATIBLE
 }

--- a/tests/src/test/scala/formulation/CompatibilitySpec.scala
+++ b/tests/src/test/scala/formulation/CompatibilitySpec.scala
@@ -14,19 +14,19 @@ class CompatibilitySpec extends WordSpec with Matchers {
 
   "Compatiblity" should {
     "return Full for UserV1 and UserV2 - defaults given" in {
-      AvroSchemaCompatibility(writer = v1, reader = v2) shouldBe AvroSchemaCompatibility.Full
+      AvroSchemaCompatibility(schema1 = v1, schema2 = v2) shouldBe AvroSchemaCompatibility.Full
     }
 
     "return Foward for UserV1 and UserV3 - no defaults" in {
-      AvroSchemaCompatibility(writer = v1, reader = v3) shouldBe AvroSchemaCompatibility.Forward
+      AvroSchemaCompatibility(schema1 = v1, schema2 = v3) shouldBe AvroSchemaCompatibility.Forward
     }
 
     "return Backward for UserV1 and UserV3 - no defaults" in {
-      AvroSchemaCompatibility(writer = v3, reader = v1) shouldBe AvroSchemaCompatibility.Backward
+      AvroSchemaCompatibility(schema1 = v3, schema2 = v1) shouldBe AvroSchemaCompatibility.Backward
     }
 
     "return NotCompatible for UserV1 and Generic" in {
-      AvroSchemaCompatibility(writer = v3, reader = genericSchema) shouldBe AvroSchemaCompatibility.None
+      AvroSchemaCompatibility(schema1 = v3, schema2 = genericSchema) shouldBe AvroSchemaCompatibility.None
     }
 
     "work while encoding as V1, we should get the right default values when decoding as V2" in {


### PR DESCRIPTION
Rename AvroSchemaCompatibility.apply params to `schema1` and `schema2` as the compatibility check is bidirectional